### PR TITLE
Provide payment<-->escrow integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4020,6 +4020,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
+ "pallet-escrow",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",

--- a/pallets/escrow/src/mock.rs
+++ b/pallets/escrow/src/mock.rs
@@ -79,7 +79,7 @@ impl pallet_balances::Config for Test {
 
 impl pallet_escrow::Config for Test {
 	type Event = Event;
-	type PaymentCurrency = Balances;
+	type EscrowCurrency = Balances;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/payments/Cargo.toml
+++ b/pallets/payments/Cargo.toml
@@ -21,6 +21,7 @@ frame-support = { default-features = false, version = "4.0.0-dev", git = "https:
 frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29" }
 frame-benchmarking = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29", optional = true }
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
+pallet-escrow = { version = "4.0.0-dev", default-features = false, path = "../escrow" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.26" }
 

--- a/pallets/payments/src/lib.rs
+++ b/pallets/payments/src/lib.rs
@@ -462,7 +462,7 @@ pub mod pallet {
 
 					// Unlock funds
 					T::EscrowCurrency::remove_lock(pallet_escrow::ESCROW_LOCK, &escrow_account_id);
-
+					
 					// Transfer the unlocked funds
 					T::PaymentCurrency::transfer(
 						escrow_account_id,
@@ -473,7 +473,7 @@ pub mod pallet {
 
 					let payment_amount_as_128: u128 = 
 						TryInto::<u128>::try_into(payment_amount).ok().unwrap();
-
+					let amount_as_128: u128 = TryInto::<u128>::try_into(escrow_details.amount.clone()).ok().unwrap();
 					escrow_details.amount -= payment_amount_as_128.try_into().ok().unwrap();
 					
 					// Lock the remaining funds

--- a/pallets/payments/src/lib.rs
+++ b/pallets/payments/src/lib.rs
@@ -35,6 +35,28 @@
 //! While the Crowdloan Rewards Pallet supports claiming rewards,
 //! this Payments Pallet supports the instantiation of scheduled payments
 //! as well as lump sum, one-time payments
+//!
+//! - [`Config`]
+//! - [`Call`]
+//! - [`Pallet`]
+//!
+//! ## Overview
+//!
+//! The Payments pallet provides functions for:
+//!
+//! - Setting up payments
+//! - Claiming payments
+//! - Blocking/Releasing payments from being claimed
+//!
+//! ## Interface
+//!
+//! ### Dispatchable Functions
+//!
+//! - `initialize_payment` - Creates the payment details and commits them to storage
+//! - `claim` - Transfers the next available funds to the payee's account
+//! - `block_next_payment` - Prevent the claiming of the next and all subsequent payments
+//! - `release_next_payment` - Free up the next available and all subsequent payments for claiming
+
 
 #![cfg_attr(not(feature = "std"), no_std)]
 pub use pallet::*;

--- a/pallets/payments/src/lib.rs
+++ b/pallets/payments/src/lib.rs
@@ -473,7 +473,7 @@ pub mod pallet {
 
 					let payment_amount_as_128: u128 = 
 						TryInto::<u128>::try_into(payment_amount).ok().unwrap();
-					let amount_as_128: u128 = TryInto::<u128>::try_into(escrow_details.amount.clone()).ok().unwrap();
+					//let amount_as_128: u128 = TryInto::<u128>::try_into(escrow_details.amount.clone()).ok().unwrap();
 					escrow_details.amount -= payment_amount_as_128.try_into().ok().unwrap();
 					
 					// Lock the remaining funds

--- a/pallets/payments/src/lib.rs
+++ b/pallets/payments/src/lib.rs
@@ -431,7 +431,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::PaymentCurrency::transfer(
 				payment_account_id,
-				&payee,
+				payee,
 				payment_amount,
 				AllowDeath,
 			)
@@ -461,12 +461,12 @@ pub mod pallet {
 					);
 
 					// Unlock funds
-					T::EscrowCurrency::remove_lock(pallet_escrow::ESCROW_LOCK, &escrow_account_id);
+					T::EscrowCurrency::remove_lock(pallet_escrow::ESCROW_LOCK, escrow_account_id);
 					
 					// Transfer the unlocked funds
 					T::PaymentCurrency::transfer(
 						escrow_account_id,
-						&payee,
+						payee,
 						payment_amount,
 						AllowDeath,
 					)?;
@@ -479,7 +479,7 @@ pub mod pallet {
 					// Lock the remaining funds
 					T::EscrowCurrency::set_lock(
 						pallet_escrow::ESCROW_LOCK,
-						&escrow_account_id,
+						escrow_account_id,
 						escrow_details.amount,
 						WithdrawReasons::all(),
 					);

--- a/pallets/payments/src/mock.rs
+++ b/pallets/payments/src/mock.rs
@@ -29,6 +29,7 @@ frame_support::construct_runtime!(
         Payments: pallet_payments::{Pallet, Call, Storage, Event<T>},
         Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		EscrowModule: pallet_escrow::{Pallet, Call, Storage, Event<T>},
 	}
 );
 
@@ -65,6 +66,11 @@ impl pallet_payments::Config for Test {
 	type RFPReferenceId = u32;
 	type PaymentCurrency = Balances;
 	type TimeProvider = pallet_timestamp::Pallet<Test>;
+}
+
+impl pallet_escrow::Config for Test {
+	type Event = Event;
+	type EscrowCurrency = Balances;
 }
 
 pub fn test_externalities() -> sp_io::TestExternalities {

--- a/pallets/payments/src/tests.rs
+++ b/pallets/payments/src/tests.rs
@@ -19,7 +19,7 @@ const PAYEE_ID: u64 = 1234;
 const PAYMENT_ID: u32 = 0001;
 const RFP_REFERENCE_ID: u32 = 966;
 const TOTAL_PAYMENT_AMOUNT: u128 = 24601;
-const ESCROW_ACCOUNT_ID: u64 = 1999;
+// const ESCROW_ACCOUNT_ID: u64 = 1999;
 const ADMINISTRATOR_ID: u64 = 1410;
 const PAYER_ID: u64 = 124;
 
@@ -49,8 +49,8 @@ fn test_initialize_payment() {
             scheduled_payment_2
         ];
         let payment_method = pallet_payments::PaymentMethod::<Test>{
-            payment_source: pallet_payments::PaymentSource::EscrowAccount,
-            account_id: ESCROW_ACCOUNT_ID,
+            payment_source: pallet_payments::PaymentSource::PersonalAccount,
+            account_id: PAYER_ID,
         };
         let payment_details = pallet_payments::PaymentDetails::<Test> {
             payer: PAYER_ID,
@@ -73,7 +73,7 @@ fn test_initialize_payment() {
         );
         let expected_event = 
             crate::Event::PaymentInitialized(
-                ESCROW_ACCOUNT_ID, 
+                PAYER_ID, 
                 PAYEE_ID, 
                 TOTAL_PAYMENT_AMOUNT
             );
@@ -87,13 +87,13 @@ fn test_claim_successful_payment() {
     t.execute_with(|| {
         assert!(System::events().is_empty());
         let _ = <Test as MyConfig>::PaymentCurrency::deposit_creating(
-            &ESCROW_ACCOUNT_ID, 
+            &PAYER_ID, 
             TOTAL_PAYMENT_AMOUNT
         );
 
         assert_eq!(
             <Test as MyConfig>::PaymentCurrency::total_balance(
-                &ESCROW_ACCOUNT_ID
+                &PAYER_ID
             ), 
             TOTAL_PAYMENT_AMOUNT
         );
@@ -113,8 +113,8 @@ fn test_claim_successful_payment() {
             scheduled_payment_2.clone()
         ];
         let payment_method = pallet_payments::PaymentMethod::<Test>{
-            payment_source: pallet_payments::PaymentSource::EscrowAccount,
-            account_id: ESCROW_ACCOUNT_ID,
+            payment_source: pallet_payments::PaymentSource::PersonalAccount,
+            account_id: PAYER_ID,
         };
         let payment_details = pallet_payments::PaymentDetails::<Test> {
             payer: PAYER_ID,
@@ -154,7 +154,7 @@ fn test_claim_successful_payment() {
         );
         assert_eq!(
             <Test as MyConfig>::PaymentCurrency::total_balance(
-                &ESCROW_ACCOUNT_ID
+                &PAYER_ID
             ), 
             TOTAL_PAYMENT_AMOUNT - (TOTAL_PAYMENT_AMOUNT / 2),
         );
@@ -174,7 +174,7 @@ fn test_claim_fails_before_payment_date() {
     t.execute_with(|| {
         assert!(System::events().is_empty());
         let _ = <Test as MyConfig>::PaymentCurrency::deposit_creating(
-            &ESCROW_ACCOUNT_ID, 
+            &PAYER_ID, 
             TOTAL_PAYMENT_AMOUNT
         );
         let time: u64 = <timestamp::Pallet<Test>>::now();
@@ -187,8 +187,8 @@ fn test_claim_fails_before_payment_date() {
             scheduled_payment.clone(), 
         ];
         let payment_method = pallet_payments::PaymentMethod::<Test>{
-            payment_source: pallet_payments::PaymentSource::EscrowAccount,
-            account_id: ESCROW_ACCOUNT_ID,
+            payment_source: pallet_payments::PaymentSource::PersonalAccount,
+            account_id: PAYER_ID,
         };
         let payment_details = pallet_payments::PaymentDetails::<Test> {
             payer: PAYER_ID,
@@ -223,7 +223,7 @@ fn test_claim_fails_before_payment_date() {
         );
         assert_eq!(
             <Test as MyConfig>::PaymentCurrency::total_balance(
-                &ESCROW_ACCOUNT_ID
+                &PAYER_ID
             ), 
             TOTAL_PAYMENT_AMOUNT,
         );
@@ -242,7 +242,7 @@ fn test_block_and_unblock_payment() {
     t.execute_with(|| {
         assert!(System::events().is_empty());
         let _ = <Test as MyConfig>::PaymentCurrency::deposit_creating(
-            &ESCROW_ACCOUNT_ID, 
+            &PAYER_ID, 
             TOTAL_PAYMENT_AMOUNT
         );
         let time: u64 = <timestamp::Pallet<Test>>::now();
@@ -255,8 +255,8 @@ fn test_block_and_unblock_payment() {
             scheduled_payment.clone(), 
         ];
         let payment_method = pallet_payments::PaymentMethod::<Test>{
-            payment_source: pallet_payments::PaymentSource::EscrowAccount,
-            account_id: ESCROW_ACCOUNT_ID,
+            payment_source: pallet_payments::PaymentSource::PersonalAccount,
+            account_id: PAYER_ID,
         };
         let payment_details = pallet_payments::PaymentDetails::<Test> {
             payer: PAYER_ID,

--- a/pallets/payments/src/tests.rs
+++ b/pallets/payments/src/tests.rs
@@ -19,7 +19,7 @@ const PAYEE_ID: u64 = 1234;
 const PAYMENT_ID: u32 = 0001;
 const RFP_REFERENCE_ID: u32 = 966;
 const TOTAL_PAYMENT_AMOUNT: u128 = 24601;
-// const ESCROW_ACCOUNT_ID: u64 = 1999;
+const ESCROW_ACCOUNT_ID: u64 = 1999;
 const ADMINISTRATOR_ID: u64 = 1410;
 const PAYER_ID: u64 = 124;
 
@@ -312,6 +312,56 @@ fn test_block_and_unblock_payment() {
                 PAYMENT_ID,
             )
         );
+        assert_ok!(
+            Payments::claim(
+                Origin::signed(PAYEE_ID),
+                PAYER_ID, 
+                PAYMENT_ID
+            )
+        );
+    });
+}
+
+#[test]
+fn test_integration_with_escrow() {
+    let mut t = test_externalities();
+    t.execute_with(|| {
+        assert!(System::events().is_empty());
+        let _ = <Test as MyConfig>::PaymentCurrency::deposit_creating(
+            &ESCROW_ACCOUNT_ID, 
+            TOTAL_PAYMENT_AMOUNT
+        );
+        let time: u64 = <timestamp::Pallet<Test>>::now();
+        let scheduled_payment = pallet_payments::ScheduledPayment::<Test> {
+            payment_date: time,
+            amount_per_claim: TOTAL_PAYMENT_AMOUNT,
+            released: true,
+        };
+		assert_ok!(EscrowModule::create_escrow(Origin::signed(ESCROW_ACCOUNT_ID)));
+		assert_ok!(EscrowModule::add_admin(Origin::signed(ESCROW_ACCOUNT_ID), PAYER_ID, ESCROW_ACCOUNT_ID));
+		assert_ok!(EscrowModule::fund_escrow(Origin::signed(ESCROW_ACCOUNT_ID), ESCROW_ACCOUNT_ID, TOTAL_PAYMENT_AMOUNT));
+        let payment_schedule = bounded_vec![
+            scheduled_payment.clone(), 
+        ];
+        let payment_method = pallet_payments::PaymentMethod::<Test>{
+            payment_source: pallet_payments::PaymentSource::EscrowAccount,
+            account_id: ESCROW_ACCOUNT_ID,
+        };
+        let payment_details = pallet_payments::PaymentDetails::<Test> {
+            payer: ESCROW_ACCOUNT_ID,
+            payee: PAYEE_ID,
+            payment_id: PAYMENT_ID,
+            rfp_reference_id: RFP_REFERENCE_ID,
+            total_payment_amount: TOTAL_PAYMENT_AMOUNT.into(),
+            payment_schedule,
+            payment_method: payment_method.clone(),
+            administrator_id: ADMINISTRATOR_ID,
+        };
+        assert_ok!(Payments::initialize_payment(
+            Origin::signed(PAYER_ID),
+            payment_details
+        ));
+        
         assert_ok!(
             Payments::claim(
                 Origin::signed(PAYEE_ID),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -271,7 +271,7 @@ impl pallet_sudo::Config for Runtime {
 /// Configure the escrow pallet in pallets/escrow.
 impl pallet_escrow::Config for Runtime {
 	type Event = Event;
-	type PaymentCurrency = Balances;
+	type EscrowCurrency = Balances;
 }
 
 // Configure the payments contract pallet in pallets/payments


### PR DESCRIPTION
Properly integrate payments and escrow pallet

- tightly couple the two pallets
- If a payment is set to escrow, unlock funds, transfer them, then lock the funds again