### PR TITLE
Temp Fix: docker build 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@ RUN set -eux && \
 	# install `rust-src` component for ui test
 	rustup component add rust-src rustfmt clippy && \
 	# install specific Rust nightly, default is stable, use minimum components
-	rustup toolchain install nightly-2022-07-25 --profile minimal --component rustfmt clippy && \
-	# "alias" pinned nightly-2022-07-25 toolchain as nightly
-	ln -s /usr/local/rustup/toolchains/nightly-2022-07-25-x86_64-unknown-linux-gnu /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
+	rustup toolchain install nightly-2023-01-10 --profile minimal --component rustfmt clippy && \
+	# "alias" pinned nightly-2023-01-10 toolchain as nightly
+	ln -s /usr/local/rustup/toolchains/nightly-2023-01-10-x86_64-unknown-linux-gnu /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
 	# install wasm toolchain
 	rustup target add wasm32-unknown-unknown && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 
 # Changes: Created temp image for build, Specified ventur node build folders, Copied binaries to ubuntu image
 
-FROM rust as temp
+FROM rust:1.65 as temp
 
 # Build dependencies
 RUN apt-get update && apt-get install -y git clang libclang-dev curl libssl-dev llvm libudev-dev pkg-config make cmake libprotobuf-dev protobuf-compiler

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.2"
 services:
   dev:
     container_name: ventur-node
-    image: paritytech/ci-linux:production
+    image: paritytech/ci-linux:production@sha256:c0ef0e660d4db2b33d0c89bc37a5110026951d5d68c83876466498aef98b6662
     working_dir: /var/www/ventur-node
     ports:
       - "9944:9944"


### PR DESCRIPTION
- Revert to older version of rust 1.65 while issues on 1.66 is pending resolution 
- Revert to older version of parity/ci-linux image sha256:c0ef0e660d4db2b33d0c89bc37a5110026951d5d68c83876466498aef98b6662
- Updated nightly reference to latest