### PR TITLE
refactor: allow accepting non-shortlisted bids

### DIFF
--- a/pallets/rfp/src/lib.rs
+++ b/pallets/rfp/src/lib.rs
@@ -543,14 +543,27 @@ pub mod pallet {
 					let shortlisted_bids = <RFPToShortlistedBids<T>>::get(
 						&rfp_id
 					);
-					ensure!(
-						shortlisted_bids.is_some(),
-						Error::<T>::RFPHasNoShortlist
-					);
-					ensure!(
-						shortlisted_bids.unwrap().contains(&bid_id),
-						Error::<T>::AcceptedBidNotShortlisted
-					);
+
+					if shortlisted_bids.is_some() {
+						// If there has been a shortlisting process, 
+						// ensure that the bid to be accepted has been
+						// shortlisted
+						ensure!(
+							shortlisted_bids.unwrap().contains(&bid_id),
+							Error::<T>::AcceptedBidNotShortlisted
+						);
+					} else {
+						// Otherwise, just make sure the bid exists
+						let all_bids_for_rfp = <RFPToBids<T>>::get(
+							&rfp_id,
+						).ok_or(
+							Error::<T>::NoBidsForRFP
+						)?;
+						ensure!(
+							all_bids_for_rfp.contains(&bid_id),
+							Error::<T>::NoSuchBidForRFP
+						);
+					}
 		
 					ensure!(
 						<RFPToAcceptedBid<T>>::get(&rfp_id).is_none(),

--- a/pallets/rfp/src/tests.rs
+++ b/pallets/rfp/src/tests.rs
@@ -887,7 +887,7 @@ fn test_accept_rfp_bid_fails_if_bid_not_shortlisted() {
 }
 
 #[test]
-fn test_accept_rfp_bid_fails_if_no_shortlist() {
+fn test_accept_rfp_bid_fails_if_bid_doesnt_exist() {
     let mut t = test_externalities();
     t.execute_with(||
     {
@@ -940,7 +940,7 @@ fn test_accept_rfp_bid_fails_if_no_shortlist() {
                 OTHER_BID_ID,
                 payment_details.clone()
             ),
-            Error::<Test>::RFPHasNoShortlist
+            Error::<Test>::NoSuchBidForRFP
         );
     })
 }


### PR DESCRIPTION
Summary: 

Previously, if a bid wasn't shortlisted, we wouldn't allow accepting it. Now, allow accepting the bid, as long as there are no shortlisted bids. If there are shortlisted bids, make sure that the accepted bid is shortlisted. 

Test: 

cargo test